### PR TITLE
Add dependency install info for ArchLinux (and derivatives)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -113,10 +113,18 @@ cd RTFM
 
 ### Install Dependencies
 
+For Debian/Ubuntu:
 ```bash
 gem install rcurses termpix bootsnap
 # Optional for all features:
 sudo apt install imagemagick w3m-img xdotool bat pandoc
+```
+
+For ArchLinux and derivatives:
+```bash
+gem install rcurses termpix bootsnap
+# Optional for all features:
+sudo pacman -Syu bat pandoc w3m imagemagick xdotool
 ```
 
 ### Run from Source

--- a/README.md
+++ b/README.md
@@ -115,6 +115,17 @@ sudo apt install ruby-full x11-utils xdotool bat pandoc poppler-utils \
 gem install rtfm-filemanager
 ```
 
+#### ArchLinux/derivatives
+```bash
+sudo pacman -Syu ruby bat pandoc poppler odt2txt docx2txt unzip gnumeric catdoc w3m imagemagick ffmpegthumbnailer
+gem install rtfm-filemanager
+```
+
+The catppt tool is not currently available. If you have an AUR helper installed, such as yay, you can install xls2csv:
+```
+yay -Syu perl-xls2csv
+```
+
 #### macOS:
 ```bash
 brew install ruby imagemagick w3m bat pandoc poppler

--- a/bin/rtfm
+++ b/bin/rtfm
@@ -464,11 +464,15 @@ def display_welcome_message # {{{2
 @firstrun += "
   • Linux (Debian/Ubuntu): Use apt
   • Linux (Fedora/RHEL): Use dnf/yum
+  • Linux (ArchLinux): Use pacman
   • macOS: Use Homebrew (brew)
   • BSD: Use pkg or ports
 
   For Ubuntu/Debian users, install all dependencies with:
   sudo apt install ruby-full git libncurses-dev x11-utils xdotool bat pandoc poppler-utils odt2txt docx2txt unzip gnumeric catdoc w3m imagemagick ffmpegthumbnailer
+  
+  For users of ArchLinux and derivatives, install all dependencies available outside of AUR with:
+  sudo pacman -Syu ruby git ncurses xdotool bat pandoc poppler odt2txt docx2txt unzip gnumeric catdoc w3m imagemagick ffmpegthumbnailer
 
   Note: Package names may vary between platforms. The 'libncurses-dev' package is Linux-specific.".b.fg(87)
 @firstrun += "\n\n

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -21,6 +21,14 @@ sudo apt install ruby-full x11-utils xdotool bat pandoc poppler-utils \
 gem install rtfm-filemanager
 ```
 
+#### ArchLinux/derivatives
+```bash
+sudo pacman -Syu ruby xdotool bat pandoc poppler odt2txt docx2txt unzip \
+  gnumeric catdoc w3m imagemagick ffmpegthumbnailer tar gzip bzip2 xz unrar 7zip
+
+gem install rtfm-filemanager
+```
+
 ### macOS
 
 ```bash

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -40,10 +40,13 @@ ruby --version
 # Update Ruby (Ubuntu)
 sudo apt install ruby-full
 
+# Update Ruby (ArchLinux)
+sudo pacman -Syu ruby
+
 # Update Ruby (macOS)
 brew install ruby
 
-# Or use rbenv/rvm for version management
+# Or use rbenv/rvm/asdf for version management
 ```
 
 ## Display Issues


### PR DESCRIPTION
I tried to stick to what I found at the various locations without knowing why each location specifies the dependencies that it does. Let me know if further changes are required before this can be merged.